### PR TITLE
options.locales -> options.languages (fixes #1)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@
 
 module.exports = function(grunt) {
 
-  var projectLocales = ['en_US', 'fr', 'es'];
+  var projectLanguages = ['en-US', 'fr', 'es'];
 
   // Project configuration.
   grunt.initConfig({
@@ -107,19 +107,19 @@ module.exports = function(grunt) {
       default: {
         options: {
           template: 'tests/tmp/messages.pot',
-          locales: projectLocales,
+          languages: projectLanguages,
           localeDir: 'tests/tmp',
         }
       },
       templatenoexist: {
         options: {
-          locales: projectLocales,
+          languages: projectLanguages,
           template: 'tests/tmp/noexist.pot',
         }
       },
       commandnoexist: {
         options: {
-          locales: projectLocales,
+          languages: projectLanguages,
           template: 'tests/tmp/messages.pot',
           cmd: 'tests/bin/whatevs.sh',
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/muffinresearch/grunt-i18n-abide.png?branch=master)](https://travis-ci.org/muffinresearch/grunt-i18n-abide)
+[![Build Status](https://travis-ci.org/mozilla/grunt-i18n-abide.png?branch=master)](https://travis-ci.org/mozilla/grunt-i18n-abide)
 [![NPM version](https://badge.fury.io/js/grunt-i18n-abide.png)](http://badge.fury.io/js/grunt-i18n-abide)
-[![Dependency Status](https://david-dm.org/muffinresearch/grunt-i18n-abide.png?theme=shields.io)](https://david-dm.org/muffinresearch/grunt-i18n-abide)
+[![Dependency Status](https://david-dm.org/mozilla/grunt-i18n-abide.png?theme=shields.io)](https://david-dm.org/mozilla/grunt-i18n-abide)
 
 
 # grunt-i18n-abide
@@ -95,7 +95,7 @@ In your project's Gruntfile, add a section named `abideCreate` to the data objec
     default: { // Target name.
       options: {
         template: 'locale/templates/LC_MESSAGES/messages.pot', // (default: 'locale/templates/LC_MESSAGES/messages.pot')
-        locales: ['en_US', 'fr', 'es'],
+        languages: ['en-US', 'fr', 'es'],
         localeDir: 'locale',
       }
     }
@@ -110,10 +110,10 @@ Default value: `locale/templates/LC\_MESSAGES/messages.pot`
 
 The path to the template pot file strings are extracted to.
 
-#### options.locales
+#### options.languages
 Type: `Array`
 
-A list of the locales you want to create.
+A list of the language codes you want to create locales for e.g. en-US not en_US.
 
 #### options.template
 Type: `String`
@@ -211,7 +211,7 @@ grunt.initConfig({
     default: { // Target name.
       options: {
         template: 'locale/templates/LC_MESSAGES/messages.pot', // (default: 'locale/templates/LC_MESSAGES/messages.pot')
-        locales: locales,
+        languages: ['en-US', 'fr', 'es'],
         localeDir: 'locale',
       }
     }
@@ -265,6 +265,11 @@ Bear in mind this code only wraps `jsxgettext` and standard `gettext` tools. If 
 
 ## Release History
 
+* 0.0.5:
+    * options.locales -> options.languages in abideCreate
+    * fix dir creation.
+    * Move npm images to mozilla repo.
+    * Update package.json
 * 0.0.4: Updated deps.
 * 0.0.3: Updated for initial npm release.
 * 0.0.2: Updates related to jsxgettext changes.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "grunt-i18n-abide",
   "description": "Grunt plugin for running jsxgettext against your codebase.",
-  "version": "0.0.4",
-  "homepage": "https://github.com/muffinresearch/grunt-i18n-abide",
+  "version": "0.0.5",
+  "homepage": "https://github.com/mozilla/grunt-i18n-abide",
   "author": {
     "name": "Stuart Colville",
     "email": "scolville@mozilla.com",
@@ -10,10 +10,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/muffinresearch/grunt-i18n-abide.git"
+    "url": "git://github.com/mozilla/grunt-i18n-abide.git"
   },
   "bugs": {
-    "url": "https://github.com/muffinresearch/grunt-i18n-abide/issues"
+    "url": "https://github.com/mozilla/grunt-i18n-abide/issues"
   },
   "licenses": [
     {

--- a/tasks/abidecreate.js
+++ b/tasks/abidecreate.js
@@ -22,14 +22,18 @@ module.exports = function (grunt) {
       grunt.fail.fatal('template file "' + template + '" does not exist');
     }
 
-    var locales = options.locales || [];
-    if (locales.length === 0) {
-      grunt.fail.fatal('A list of locales needs to be specified.');
+    var languages = options.languages || [];
+    if (languages.length === 0) {
+      grunt.fail.fatal('A list of languages needs to be specified.');
     }
 
-    locales.forEach(function(locale) {
+    languages.forEach(function(language) {
+      // en-US -> en_US
+      var locale = helpers.localeFrom(language);
+
       // Make the dir for the locale.
       var args = [];
+
       var outputFile = path.join(baseLocaleDir, locale, 'LC_MESSAGES/messages.po');
       var cmd = options.cmd || 'msginit';
 

--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -1,3 +1,5 @@
+var util = require('util');
+
 var shell = require('shelljs');
 var grunt = require('grunt');
 
@@ -17,5 +19,37 @@ exports.checkCommand = function checkCommand(cmd) {
   var result = shell.exec('bash -c "type -P ' + cmd + ' > /dev/null"');
   if (result.code !== 0) {
     grunt.fail.fatal('Command "' + cmd + '" doesn\'t exist! Maybe you need to install it.');
+  }
+};
+
+
+/**
+* Given a language code, return a locale code the OS understands.
+* Based on from: https://github.com/mozilla/i18n-abide/blob/master/lib/i18n.js
+*
+* language: en-US
+* locale: en_US
+*/
+exports.localeFrom = function(language) {
+  if (! language || ! language.split) {
+    return "";
+  }
+
+  if (language.indexOf('_') > -1) {
+    grunt.log.writeln(util.format("Check this is a language code. Language [%s] already contains a '_'", language));
+    return language;
+  }
+
+  var parts = language.split('-');
+  if (parts.length === 1) {
+    return parts[0].toLowerCase();
+  } else if (parts.length === 2) {
+    return util.format('%s_%s', parts[0].toLowerCase(), parts[1].toUpperCase());
+  } else if (parts.length === 3) {
+    // sr-Cyrl-RS should be sr_RS
+    return util.format('%s_%s', parts[0].toLowerCase(), parts[2].toUpperCase());
+  } else {
+    grunt.log.writeln(util.format("Unable to map a locale from language code [%s]", language));
+    return language;
   }
 };


### PR DESCRIPTION
`grunt abideCreate` didn't create dirs correctly causing i18n-abide to correctly complain about locale dirs it can't find.

This branch renames `options.locales` to `options.languages` so that it's clearer a list of langs not locales should be supplied. E.g. a lang code is en-US whereas a locale for that code would be en_US.

Subsequently the locales are then created based on lang codes so en-US will result in the en_US locale.

At the same time I've cleaned up the repo references to point here and bumped the version.
