### PR TITLE
Allow jsVar config and output locale/lang in js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,6 +181,33 @@ module.exports = function(grunt) {
           createJSFiles: true,
         }
       },
+      jsvar: {
+        dest: 'tests/tmp/jsvar/',
+        options: {
+          type: 'json',
+          localeDir: 'tests/tmp',
+          createJSFiles: true,
+          jsVar: 'whatever',
+        }
+      },
+      badjsvar: {
+        dest: 'tests/tmp/badjsvar/',
+        options: {
+          type: 'json',
+          localedir: 'tests/tmp',
+          createjsfiles: true,
+          jsVar: 'try', // reserved word.
+        }
+      },
+      badjsvar2: {
+        dest: 'tests/tmp/badjsvar2/',
+        options: {
+          type: 'json',
+          localedir: 'tests/tmp',
+          createjsfiles: true,
+          jsVar: '15643785', // starts with number.
+        }
+      },
       json: {
         dest: 'tests/tmp/json/',
         options: {
@@ -270,6 +297,7 @@ module.exports = function(grunt) {
     'abideCompile:mo',
     'abideCompile:nojs',
     'abideCompile:yesjs',
+    'abideCompile:jsvar',
 
     // Test all the things.
     'nodeunit'

--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ Only relevant when `options.type` is set to `'json'`.
 If `false` the JS files won't be created alongside the json. If you don't need the js
 e.g. you're not producing a client-side app that uses the JS then set this to `false`.
 
+#### options.jsVar
+Type: `String`
+Default value: `json_locale_data`
+
+Allows you to override the JS var used in the JS output. The var is added to the window object.
+So by default you'll end up with window.json_locale_data. This value is crudely validated to
+help ensure you don't use a reserved word or an invalid property name.
+
 #### options.localeDir
 Type: `String`
 Default value: `locale`
@@ -274,7 +282,10 @@ Bear in mind this code only wraps `jsxgettext` and standard `gettext` tools. If 
 
 ## Release History
 
-
+* 0.0.8:
+    * Provide configuration for jsVar in js output.
+    * Output lang/locale for js output.
+    * Update po2json + jsxgettext.
 * 0.0.7:
     * Fix bug if createJSFiles is true.
 * 0.0.6:
@@ -285,7 +296,11 @@ Bear in mind this code only wraps `jsxgettext` and standard `gettext` tools. If 
     * fix dir creation.
     * Move npm images to mozilla repo.
     * Update package.json.
-* 0.0.4: Updated deps.
-* 0.0.3: Updated for initial npm release.
-* 0.0.2: Updates related to jsxgettext changes.
-* 0.0.1: Initial version.
+* 0.0.4:
+    * Updated deps.
+* 0.0.3:
+    * Updated for initial npm release.
+* 0.0.2:
+    * Updates related to jsxgettext changes.
+* 0.0.1:
+    * Initial version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-i18n-abide",
   "description": "Grunt plugin for running jsxgettext against your codebase.",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "homepage": "https://github.com/mozilla/grunt-i18n-abide",
   "author": {
     "name": "Stuart Colville",

--- a/tasks/abidemerge.js
+++ b/tasks/abidemerge.js
@@ -32,11 +32,11 @@ module.exports = function (grunt) {
       return file.match(/\.po$/);
     });
 
-    files.forEach(function(lang){
+    files.forEach(function(locale){
       var args = [];
       var moveArgs = [];
-      var dir = path.dirname(lang);
-      var stem = path.basename(lang, '.po');
+      var dir = path.dirname(locale);
+      var stem = path.basename(locale, '.po');
 
       var cmd = options.cmd || 'msgmerge';
       checkCommand(cmd);

--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -25,7 +25,7 @@ exports.checkCommand = function checkCommand(cmd) {
 
 /**
 * Given a language code, return a locale code the OS understands.
-* Based on from: https://github.com/mozilla/i18n-abide/blob/master/lib/i18n.js
+* Based on: https://github.com/mozilla/i18n-abide/blob/master/lib/i18n.js
 *
 * language: en-US
 * locale: en_US
@@ -51,5 +51,28 @@ exports.localeFrom = function(language) {
   } else {
     grunt.log.writeln(util.format("Unable to map a locale from language code [%s]", language));
     return language;
+  }
+};
+
+
+/**
+* Given a locale code, return a language code
+* Based on: https://github.com/mozilla/i18n-abide/blob/master/lib/i18n.js
+*/
+exports.languageFrom = function languageFrom(locale) {
+  if (!locale || !locale.split) {
+    return "";
+  }
+  var parts = locale.split('_');
+  if (parts.length === 1) {
+    return parts[0].toLowerCase();
+  } else if (parts.length === 2) {
+    return util.format('%s-%s', parts[0].toLowerCase(), parts[1].toUpperCase());
+  } else if (parts.length === 3) {
+    // sr_RS should be sr-RS
+    return util.format('%s-%s', parts[0].toLowerCase(), parts[2].toUpperCase());
+  } else {
+    grunt.log.writeln(util.format("Unable to map a language from locale code [%s]", locale));
+    return locale;
   }
 };

--- a/tests/abidecompile_test.js
+++ b/tests/abidecompile_test.js
@@ -59,6 +59,18 @@ exports.compile = {
     test.ok(utils.contains('updated1', grunt.file.read(jsonFile)));
     test.done();
   },
+  testJSVar: function(test) {
+    test.expect(5);
+    var jsFile = 'tests/tmp/jsvar/en_US/messages.js';
+    var jsonFile = 'tests/tmp/jsvar/en_US/messages.json';
+    test.ok(grunt.file.exists(jsFile));
+    test.ok(grunt.file.exists(jsonFile));
+    var jsFileContent = grunt.file.read(jsFile);
+    test.ok(utils.contains('window.whatever', jsFileContent));
+    test.ok(utils.contains('window.whatever.lang = "en-US";', jsFileContent));
+    test.ok(utils.contains('window.whatever.locale = "en_US";', jsFileContent));
+    test.done();
+  },
   testFR: function(test) {
     test.expect(5);
     var jsFile = 'tests/tmp/json/fr/messages.js';
@@ -81,6 +93,18 @@ exports.compile = {
     test.ok(grunt.file.exists(moFile));
     test.ok(utils.contains('updated1', grunt.file.read(jsFile)));
     test.ok(utils.contains('updated1', grunt.file.read(jsonFile)));
+    test.done();
+  },
+  testBadJSVar: function(test) {
+    test.expect(1);
+    var result = shell.exec('grunt abideCompile:badjsvar');
+    test.ok(utils.contains('is an invalid var name', result.output));
+    test.done();
+  },
+  testBadJSVar2: function(test) {
+    test.expect(1);
+    var result = shell.exec('grunt abideCompile:badjsvar2');
+    test.ok(utils.contains('is an invalid var name', result.output));
     test.done();
   },
 };


### PR DESCRIPTION
This allows the config of the jsVar and also outputs the lang and locale directly onto the defined object.
