### PR TITLE
close fs to avoid "Warning: EPERM, operation not permitted 'C:\Users\xxx...

### DIFF
--- a/tasks/abidecompile.js
+++ b/tasks/abidecompile.js
@@ -28,7 +28,8 @@ module.exports = function (grunt) {
   'use strict';
 
   function createLockFile() {
-    return fs.openSync(lockFilePath, 'w');
+    var fd = fs.openSync(lockFilePath, 'w');
+    fs.closeSync(fd);
   }
 
   function removeLockFile() {


### PR DESCRIPTION
close fd to avoid "Warning: EPERM, operation not permitted 'C:\Users\xxxx\AppData\Local\Temp\2\abideCompile.lock' Use --force to continue." error when watch files change
