### PR TITLE
abideCreate: Do not no-op on different targets and subsequently differen...

### DIFF
--- a/tasks/abidecreate.js
+++ b/tasks/abidecreate.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
       // Make the dir for the locale.
       var args = [];
 
-      var filename = path.basename(template,".pot");
+      var filename = path.basename(template, '.pot');
       var outputFile = path.join(baseLocaleDir, locale, 'LC_MESSAGES/' + filename + '.po');
 
       var cmd = options.cmd || 'msginit';


### PR DESCRIPTION
Like every other grunt-i18n-abide task abideCreate allows to define multiple
targets for itself. This can be for example the splitting of purely server-side
template translation strings and purely client-side translation strings. This is
in most cases to speed up translation delivery and overall speedcost created by
fetching overly large translation files that would otherwise contain server- and
client-side translations which is entirely unnecessairy bloat and only serves
to increase page-load-times. Also you may have seperate tools to extract gettext
information from your serverside code as from your client-side code.

Example here:
- server-side:
  - templates: nunjucks
  - translation extraction: i18n-abide translations using gettext()
  - builds: po/mo/js/json files for on the fly translation
- client-side:
  - templates: angular templates
  - translation extraction: angular-gettext with good integration into angularjs
  - builds: po/mo/js/json fils for translation post-download on the client

And so to ease the integration with the necessary client-side tools you'd need a
way to translate pot files from the extraction (in this case nggettext-extract)
into po files and then into javascript (here: nggettext-compile).

Note here that the abillity to create *.po-files has been left completely open
to the implementor and therefore needs tooling during build and to not double
the efforts of course.

grunt-i18n-abide basically is a great fit for that. This change only helping it to
become even better!
