### PR TITLE
FIxed: jsxgettext doesn't exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4.0"
+  - "4.1"
+  - "4.2"
+  - "5.0"
+  - "5.1"
+  - "iojs"
 before_script:
   - npm install -g grunt-cli
 notifications:

--- a/tasks/abidextract.js
+++ b/tasks/abidextract.js
@@ -23,9 +23,7 @@ module.exports = function (grunt) {
         fs.statSync( _path );
         cachedPath = _path;
         return _path;
-        }catch(err){
-          grunt.log.ok(err);
-      }
+        }catch(err){}
     }
     grunt.fail.fatal('Cannot find jsxgettext.');
   };

--- a/tasks/abidextract.js
+++ b/tasks/abidextract.js
@@ -4,9 +4,31 @@ var helpers = require('./lib/helpers');
 
 var runShellSync = helpers.runShellSync;
 
+var cmdPaths = [ '../../.bin/jsxgettext', '../node_modules/.bin/jsxgettext' ];
+
 module.exports = function (grunt) {
 
   'use strict';
+  
+  var cachedPath = null;
+  var getPath = function(){
+    var idx, lpaths, _path;
+    if( cachedPath ){
+      return cachedPath;
+    }
+    lpaths = cmdPaths.length;
+    for( idx = 0; idx < lpaths; idx++ ){
+      _path = path.join(__dirname, cmdPaths[idx]);
+      try{
+        fs.statSync( _path );
+        cachedPath = _path;
+        return _path;
+        }catch(err){
+          grunt.log.ok(err);
+      }
+    }
+    grunt.fail.fatal('Cannot find jsxgettext.');
+  };
 
   grunt.registerMultiTask('abideExtract', 'Extracts gettext from js, EJS or Jinja (nunjucks).', function () {
 
@@ -15,8 +37,8 @@ module.exports = function (grunt) {
       language: 'JavaScript',
       join: true,
     });
-
-    var cmd = helpers.getCommand(options.cmd || path.join(__dirname, '../node_modules/.bin/jsxgettext'));
+    
+    var cmd = helpers.getCommand(options.cmd || getPath() );
 
     var args = [];
     var filesSrc = this.filesSrc;


### PR DESCRIPTION
I fixed a problem in my development environment.
The submodule `jsxgettext`, in my case, is place directly under `node_modules/.bin/jsxgettext` not as expected under `node_modules/grunt-i18n-abide/node_modules/.bin/jsxgettext`.

So i fixed this by testing the existence of `jsxgettext` in a list of possible paths.

+ i added more node versions within your `.travis.yml`

---

**Original error:**
```
Running "abideExtract:server" (abideExtract) task
Fatal error: Command "/Users/__myname__/Projekte/__myproject__/node_modules/grunt-i18n-abide/node_modules/.bin/jsxgettext" doesn't exist! Maybe you need to install it.
```

---

**My Env:**
node: `v0.10.25`
npm: `3.3.12`